### PR TITLE
Initial commit of OpenMetrics output

### DIFF
--- a/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
+++ b/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
@@ -17,6 +17,7 @@
 package io.warp10.sensision;
 
 import java.io.PrintWriter;
+import java.net.URLEncoder;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -34,12 +35,33 @@ public class OpenMetrics {
 
     out.print(sanitizeClassName(name));
 
+    //
+    // Add default labels
+    //
+    boolean first = true;
+
+    for (String label: Sensision.defaultLabels.keySet()) {
+      if (!labels.containsKey(label)) {
+        if (!first) {
+          out.print(",");
+        } else {
+          out.print("{");
+        }
+        out.print(sanitizeLabelName(label));
+        out.print("=");
+        out.print("\"");
+        out.print(sanitizeLabelValue(Sensision.defaultLabels.get(label)));
+        out.print("\"");
+        first = false;
+      }
+    }
+
     if (null != labels && !labels.isEmpty()) {
-      out.print("{");
-      boolean first = true;
       for (Entry<String,String> label: labels.entrySet()) {
         if (!first) {
           out.print(",");
+        } else {
+          out.print("{");
         }
         out.print(sanitizeLabelName(label.getKey()));
         out.print("=");
@@ -48,6 +70,9 @@ public class OpenMetrics {
         out.print("\"");
         first = false;
       }
+    }
+
+    if (!first) {
       out.print("}");
     }
 
@@ -57,7 +82,7 @@ public class OpenMetrics {
       out.print(" ");
       out.print(timestamp);
     }
-    // OpenMetrics mandates that line end with a LF and no CR
+    // OpenMetrics mandates that line ends with a LF and no CR
     out.print("\n");
   }
 

--- a/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
+++ b/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
@@ -1,3 +1,19 @@
+//
+//   Copyright 2022  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
 package io.warp10.sensision;
 
 import java.io.PrintWriter;
@@ -176,7 +192,7 @@ public class OpenMetrics {
     // Label values must have \n, \ and " escaped by \
     //
 
-    value = value.replaceAll("\\", "\\\\");
+    value = value.replaceAll("\\\\", "\\\\\\\\");
     value = value.replaceAll("\n", "\\n");
     value = value.replaceAll("\"", "\\\"");
 

--- a/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
+++ b/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2022  SenX S.A.S.
+//   Copyright 2022-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -185,14 +185,14 @@ public class OpenMetrics {
     }
   }
 
-  private static String sanitizeLabelValue(String value) {
+  public static String sanitizeLabelValue(String value) {
     //
     // Label values must have \n, \ and " escaped by \
     //
 
     value = value.replaceAll("\\\\", "\\\\\\\\");
-    value = value.replaceAll("\n", "\\n");
-    value = value.replaceAll("\"", "\\\"");
+    value = value.replaceAll("\n", "\\\\n");
+    value = value.replaceAll("\"", "\\\\\"");
 
     return value;
   }

--- a/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
+++ b/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
@@ -1,0 +1,189 @@
+package io.warp10.sensision;
+
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class OpenMetrics {
+
+  private static final boolean useOpenMetrics = null != System.getProperty(Sensision.SENSISION_OPENMETRICS);
+
+  public static void dump(PrintWriter out, String name, Map<String,String> labels, Long timestamp, Object value) {
+
+    //
+    // OpenMetrics only supports numerical values, ignore Strings and Booleans
+    //
+
+    if (!(value instanceof Number)) {
+      return;
+    }
+
+    out.print(sanitizeClassName(name));
+
+    if (null != labels && !labels.isEmpty()) {
+      out.print("{");
+      boolean first = true;
+      for (Entry<String,String> label: labels.entrySet()) {
+        if (!first) {
+          out.print(",");
+        }
+        out.print(sanitizeLabelName(label.getKey()));
+        out.print("=");
+        out.print("\"");
+        out.print(sanitizeLabelValue(label.getValue()));
+        out.print("\"");
+        first = false;
+      }
+      out.print("}");
+    }
+
+    out.print(" ");
+    out.print(value);
+    if (null != timestamp) {
+      out.print(" ");
+      out.print(timestamp);
+    }
+    // OpenMetrics mandates that line end with a LF and no CR
+    out.print("\n");
+  }
+
+  private static String sanitizeClassName(String name) {
+    //
+    // As per OpenMetrics format, metrics name can only contain letters, digits, _ and :
+    // and MUST start by a letter, _ or :
+    // If that is not the case for class name, adapt it by replacing forbidden chars by '_' and
+    // prefixing the name with '_' if it starts with a digit
+    //
+    // @see https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md
+    //
+
+    StringBuilder sb = null;
+
+    for (int i = 0; i < name.length(); i++) {
+      if (name.charAt(i) >= 'a' && name.charAt(i) <= 'z') {
+        if (null != sb) {
+          sb.append(name.charAt(i));
+        }
+        continue;
+      }
+      if (name.charAt(i) >= 'A' && name.charAt(i) <= 'Z') {
+        if (null != sb) {
+          sb.append(name.charAt(i));
+        }
+        continue;
+      }
+      if (name.charAt(i) >= '0' && name.charAt(i) <= '9') {
+        if (null != sb) {
+          sb.append(name.charAt(i));
+        }
+        continue;
+      }
+      if ('_' == name.charAt(i) || ':' == name.charAt(i)) {
+        if (null != sb) {
+          sb.append(name.charAt(i));
+        }
+        continue;
+      }
+      if (null == sb) {
+        sb = new StringBuilder(name.length());
+        sb.append(name, 0, i);
+      }
+      // Replace forbidden char by '_'
+      sb.append("_");
+    }
+
+    //
+    // Check the first char
+    //
+
+    if (null == sb) {
+      if (name.charAt(0) >= '0' && name.charAt(0) <= '9') {
+        return "_" + name;
+      } else {
+        return name;
+      }
+    } else {
+      if (sb.charAt(0) >= '0' && sb.charAt(0) <= '9') {
+        return "_" + sb.toString();
+      } else {
+        return sb.toString();
+      }
+    }
+  }
+
+  private static final String sanitizeLabelName(String name) {
+    //
+    // Label names in OpenMetrics can only start by a letter or '_' and can only
+    // contain letters, digits and '_'
+    //
+
+    StringBuilder sb = null;
+
+    for (int i = 0; i < name.length(); i++) {
+      if (name.charAt(i) >= 'a' && name.charAt(i) <= 'z') {
+        if (null != sb) {
+          sb.append(name.charAt(i));
+        }
+        continue;
+      }
+      if (name.charAt(i) >= 'A' && name.charAt(i) <= 'Z') {
+        if (null != sb) {
+          sb.append(name.charAt(i));
+        }
+        continue;
+      }
+      if (name.charAt(i) >= '0' && name.charAt(i) <= '9') {
+        if (null != sb) {
+          sb.append(name.charAt(i));
+        }
+        continue;
+      }
+      if ('_' == name.charAt(i)) {
+        if (null != sb) {
+          sb.append(name.charAt(i));
+        }
+        continue;
+      }
+      if (null == sb) {
+        sb = new StringBuilder(name.length());
+        sb.append(name, 0, i);
+      }
+      // Replace forbidden char by '_'
+      sb.append("_");
+    }
+
+    //
+    // Check the first char
+    //
+
+    if (null == sb) {
+      if (name.charAt(0) >= '0' && name.charAt(0) <= '9') {
+        return "_" + name;
+      } else {
+        return name;
+      }
+    } else {
+      if (sb.charAt(0) >= '0' && sb.charAt(0) <= '9') {
+        return "_" + sb.toString();
+      } else {
+        return sb.toString();
+      }
+    }
+  }
+
+  private static String sanitizeLabelValue(String value) {
+    //
+    // Label values must have \n, \ and " escaped by \
+    //
+
+    value = value.replaceAll("\\", "\\\\");
+    value = value.replaceAll("\n", "\\n");
+    value = value.replaceAll("\"", "\\\"");
+
+    return value;
+  }
+
+  public static boolean useOpenMetrics() {
+    return useOpenMetrics;
+  }
+}

--- a/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
+++ b/sensision/src/main/java/io/warp10/sensision/OpenMetrics.java
@@ -22,8 +22,6 @@ import java.util.Map.Entry;
 
 public class OpenMetrics {
 
-  private static final boolean useOpenMetrics = null != System.getProperty(Sensision.SENSISION_OPENMETRICS);
-
   public static void dump(PrintWriter out, String name, Map<String,String> labels, Long timestamp, Object value) {
 
     //
@@ -197,9 +195,5 @@ public class OpenMetrics {
     value = value.replaceAll("\"", "\\\"");
 
     return value;
-  }
-
-  public static boolean useOpenMetrics() {
-    return useOpenMetrics;
   }
 }

--- a/sensision/src/main/java/io/warp10/sensision/QueueManager.java
+++ b/sensision/src/main/java/io/warp10/sensision/QueueManager.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,28 +16,16 @@
 
 package io.warp10.sensision;
 
-import io.warp10.sensision.Sensision.Value;
-
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
-import java.io.FilenameFilter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.net.ConnectException;
-import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.net.URL;
-import java.net.URLConnection;
 import java.nio.file.DirectoryStream;
+import java.nio.file.DirectoryStream.Filter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.DirectoryStream.Filter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -48,12 +36,13 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.zip.GZIPOutputStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.MinMaxPriorityQueue;
+
+import io.warp10.sensision.Sensision.Value;
 
 /**
  * This class periodically scans the 'queued' directory and takes
@@ -61,100 +50,100 @@ import com.google.common.collect.MinMaxPriorityQueue;
  * depending on regular expressions.
  */
 public class QueueManager extends Thread {
-  
+
   private static final Logger LOGGER = LoggerFactory.getLogger(QueueManager.class);
-  
+
   public static final String SENSISION_QM_DEFAULT = "sensision.qm.default";
-  
+
   /**
    * Queue selector prefix. The rest of the parameter name is the name of the
    * target queue. The value is a selector.
    */
   public static final String SELECTOR_PREFIX = "sensision.qm.selector.";
   public static final String PENDING_SUFFIX = ".pending";
-  
+
   /**
    * Number of files to read at each scan
    */
   public static final String HTTP_TOPN = "sensision.qm.topn";
-  
+
   /**
    * Number of milliseconds between two directory scans
    */
   public static final String HTTP_PERIOD = "sensision.qm.period";
-  
+
   private final File queueDir;
-  
+
   /**
    * Maximum number of files to consider at each run
    */
   private final int topn;
-  
+
   /**
    * Delay between queue dir scans
    */
   private final long period;
-  
+
   private final Map<String,Pattern> queues = new HashMap<String, Pattern>();
 
   private final String defaultQueue;
-  
+
   public QueueManager(Properties properties) throws Exception {
     this.queueDir = Sensision.getQueueDir();
     this.topn = Integer.valueOf(properties.getProperty(HTTP_TOPN));
     this.period = Long.valueOf(properties.getProperty(HTTP_PERIOD));
-        
+
     //
     // Extract queue configuration
     //
-    
+
     for (Object key: properties.keySet()) {
       if (key.toString().startsWith(SELECTOR_PREFIX)) {
         //
         // Extract queue name
         //
-        
+
         String queue = key.toString().substring(SELECTOR_PREFIX.length());
-        
+
         if ("".equals(queue) || !"".equals(queue.replaceAll("[a-zA-z0-9_-]", ""))) {
           throw new RuntimeException("Invalid queue name at property '" + key + "'.");
         }
-        
+
         //
         // Extract regexp
         //
 
         Pattern p = Pattern.compile(properties.getProperty(key.toString()));
-        
+
         queues.put(queue, p);
       }
     }
 
     this.defaultQueue = properties.getProperty(SENSISION_QM_DEFAULT);
-    
+
     if (queues.isEmpty() && null == defaultQueue) {
       LOGGER.warn("No default queue defined, some metrics may be lost.");
     }
-    
+
     this.setDaemon(true);
     this.setName("[Sensision QueueManager]");
     this.start();
   }
-  
+
   @Override
   public void run() {
-    
+
     Map<String,PrintWriter> openQueueWriters = new HashMap<String,PrintWriter>();
     List<String> openQueueFiles = new ArrayList<String>();
-    
+
     while(true) {
-      
+
       openQueueWriters.clear();
-      
+
       int idx = 0;
-      
+
       boolean error = false;
-      
+
       DirectoryStream<Path> files = null;
 
       List<File> currentFiles = new ArrayList<File>();
@@ -163,12 +152,12 @@ public class QueueManager extends Thread {
         //
         // Retrieve a list of files to transmit
         //
-        
+
        Filter<Path> filter = new Filter<Path>() {
-          
+
           @Override
           public boolean accept(Path entry) throws IOException {
-            
+
             if (!queueDir.equals(entry.getParent().toFile()) || !entry.getName(entry.getNameCount() - 1).toString().endsWith(Sensision.SENSISION_METRICS_SUFFIX)) {
               return false;
             }
@@ -177,39 +166,39 @@ public class QueueManager extends Thread {
         };
 
         files = Files.newDirectoryStream(this.queueDir.toPath(), filter);
-        
+
         Iterator<Path> iterator = files.iterator();
 
         MinMaxPriorityQueue<Path> topfiles = MinMaxPriorityQueue.maximumSize(this.topn).create();
-        
+
         while(iterator.hasNext()) {
           topfiles.add(iterator.next());
         }
-        
+
         iterator = topfiles.iterator();
-        
+
         long now = System.currentTimeMillis();
 
         //
         // Generate a UUID for this queue manager run (now/uuid must be a unique combination)
         //
-        
+
         String uuid = UUID.randomUUID().toString();
-        
+
         while (null != files && idx < this.topn && iterator.hasNext()) {
           //
           // Open metrics file
           //
-        
+
           File file = iterator.next().toFile();
           idx++;
           currentFiles.add(file);
-          
+
           BufferedReader br = new BufferedReader(new FileReader(file));
-              
+
           while(true) {
             String line = br.readLine();
-                
+
             if (null == line) {
               break;
             }
@@ -217,9 +206,9 @@ public class QueueManager extends Thread {
             //
             // Attempt to parse metric
             //
-                
+
             Value value = Sensision.parseMetric(line);
-                
+
             // Skip invalid metrics
             if (null == value) {
               continue;
@@ -228,22 +217,22 @@ public class QueueManager extends Thread {
             //
             // Loop over the queues to determine where this metric should be sent
             //
-            
+
             boolean queued = false;
-            
+
             for (Entry<String,Pattern> entry: queues.entrySet()) {
               Matcher m = entry.getValue().matcher(value.cls);
-              
+
               if (!m.matches()) {
                 continue;
               }
-              
+
               //
               // Check if we have an open OutputStream for the current queue
               //
-              
+
               PrintWriter out = openQueueWriters.get(entry.getKey());
-              
+
               if (null == out) {
                 StringBuilder sb = new StringBuilder();
 
@@ -253,11 +242,11 @@ public class QueueManager extends Thread {
                 sb.append(".");
                 sb.append(entry.getKey());
                 sb.append(Sensision.SENSISION_QUEUED_SUFFIX);
-        
+
                 openQueueFiles.add(sb.toString());
-                
+
                 sb.append(PENDING_SUFFIX);
-                
+
                 out = new PrintWriter(new File(Sensision.getQueueDir(), sb.toString()));
                 openQueueWriters.put(entry.getKey(), out);
               }
@@ -265,12 +254,12 @@ public class QueueManager extends Thread {
               //
               // Output the value
               //
-              
-              Sensision.dumpValue(out, value, true, true);
-              
+
+              Sensision.dumpValue(out, value, true, true, false);
+
               queued = true;
-            }               
-            
+            }
+
             if (!queued && null != defaultQueue) {
               PrintWriter out = openQueueWriters.get(defaultQueue);
 
@@ -283,11 +272,11 @@ public class QueueManager extends Thread {
                 sb.append(".");
                 sb.append(defaultQueue);
                 sb.append(Sensision.SENSISION_QUEUED_SUFFIX);
-        
+
                 openQueueFiles.add(sb.toString());
-                
+
                 sb.append(PENDING_SUFFIX);
-                
+
                 out = new PrintWriter(new File(Sensision.getQueueDir(), sb.toString()));
                 openQueueWriters.put(defaultQueue, out);
               }
@@ -295,13 +284,13 @@ public class QueueManager extends Thread {
               //
               // Output the value
               //
-              
-              Sensision.dumpValue(out, value, true, true);              
+
+              Sensision.dumpValue(out, value, true, true, false);
             }
           }
           br.close();
         }
-      } catch (IOException ioe) { 
+      } catch (IOException ioe) {
         error = true;
         LOGGER.error("Caught IO exception in 'run'", ioe);
         if (ioe instanceof ConnectException) {
@@ -311,47 +300,47 @@ public class QueueManager extends Thread {
         error = true;
         LOGGER.error("Caught exception in 'run'", e);
       } finally {
-        
+
         if (null != files) {
           try { files.close(); } catch (IOException ioe) {}
         }
-        
+
         //
         // Close open queue files
         //
-        
+
         for (PrintWriter pw: openQueueWriters.values()) {
           pw.close();
         }
 
         openQueueWriters.clear();
 
-        if (!error) {          
+        if (!error) {
           for (String filename: openQueueFiles) {
             File file = new File(Sensision.getQueueDir(), filename + PENDING_SUFFIX);
             file.renameTo(new File(Sensision.getQueueDir(), filename));
           }
-          
+
           //
           // Remove ventilated files
           //
-          
+
           for (File file: currentFiles) {
             file.delete();
-          }          
+          }
         } else {
           for (String filename: openQueueFiles) {
             File file = new File(Sensision.getQueueDir(), filename + PENDING_SUFFIX);
             file.delete();
           }
         }
-        
+
         openQueueFiles.clear();
       }
-      
+
       try {
         Thread.sleep(this.period);
-      } catch(InterruptedException ie) {        
+      } catch(InterruptedException ie) {
       }
     }
   }

--- a/sensision/src/main/java/io/warp10/sensision/Sensision.java
+++ b/sensision/src/main/java/io/warp10/sensision/Sensision.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2021  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/sensision/src/main/java/io/warp10/sensision/Sensision.java
+++ b/sensision/src/main/java/io/warp10/sensision/Sensision.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
 //
 
 package io.warp10.sensision;
-
-import io.warp10.Revision;
-import io.warp10.sensision.FilePoller;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -50,7 +47,7 @@ import java.util.regex.Pattern;
  * Sensision is the main class of the Sensision metrics collection
  * system. It contains methods for setting, updating and reading
  * values.
- * 
+ *
  * INFO(hbs): sticky bit is needed on 'targets/*', 'metrics', 'queued' directories
  * with owner 'sensision' and mode 1777
  */
@@ -65,18 +62,20 @@ public class Sensision {
   /**
    * Time at which this Sensision class started to be
    */
-  private static long starttime = System.currentTimeMillis();  
+  private static long starttime = System.currentTimeMillis();
 
   private static List<Iterable<Value>> providers = new ArrayList<Iterable<Value>>();
-  
+
   public static final String SENSISION_DISABLE = "sensision.disable";
   public static final String SENSISION_TIME_UNIT = "sensision.timeunit";
   public static final String SENSISION_INSTANCE = "sensision.instance";
-  
+
   public static final String SENSISION_QUEUEMANAGER = "sensision.queuemanager";
   public static final String SENSISION_POLLERS = "sensision.pollers";
   public static final String SENSISION_HTTP_TOKEN_HEADER_DEFAULT = "X-Warp10-Token";
-  
+
+  public static final String SENSISION_OPENMETRICS = "sensision.openmetrics";
+
   public static final String HTTP_HEADER_UUID = "X-UUID";
   public static final String HTTP_HEADER_TIMESTAMP = "X-Timestamp";
   public static final String HTTP_HEADER_LASTEVENT = "X-Sensision-LastEvent";
@@ -94,30 +93,30 @@ public class Sensision {
   public static final long DEFAULT_DUMP_PERIOD = 10000L;
 
   public static final String SENSISION_CONFIG_FILE = "sensision.config";
-  
+
   private static final String SENSISION_QUEUE_SUBDIR = "queued";
   public static final String SENSISION_QUEUED_SUFFIX = ".queued";
-  
+
   public static final String SENSISION_METRICS_SUBDIR = "metrics";
   public static final String SENSISION_METRICS_SUFFIX = ".metrics";
-  
+
   public static final String SENSISION_HOME = "sensision.home";
 
   /**
    * Number of events in the circular history buffer
    */
   public static final String SENSISION_EVENTS_HISTORY = "sensision.events.history";
-  
+
   /**
    * Suffix to use for the events files
    */
   public static final String SENSISION_EVENTS_SUFFIX = "sensision.events.suffix";
-  
+
   /**
    * Directory where events files should be created
    */
   public static final String SENSISION_EVENTS_DIR = "sensision.events.dir";
-  
+
   public static final String DEFAULT_SENSISION_POLLING_HINT = "60000";
 
   public static final String DEFAULT_SENSISION_URLDEBUG = "false";
@@ -128,18 +127,18 @@ public class Sensision {
    * Should be used when lots of metrics are created with similar labels.
    */
   public static final String SENSISION_STRING_OPTIMIZE = "sensision.string.optimize";
-  
+
   public static final String SENSISION_HTTPPOLLER_SLEEP = "sensision.poller.http.sleep";
   public static final String SENSISION_HTTPPOLLER_SCANPERIOD = "sensision.poller.http.scanperiod";
   public static final String SENSISION_HTTPPOLLER_FORCEDHINT = "sensision.poller.http.forcedhint";
-  
+
   public static final String SENSISION_SCRIPTRUNNER = "sensision.scriptrunner";
   public static final String SENSISION_SCRIPTRUNNER_ROOT = "sensision.scriptrunner.root";
   public static final String SENSISION_SCRIPTRUNNER_NTHREADS = "sensision.scriptrunner.nthreads";
   public static final String SENSISION_SCRIPTRUNNER_SCANPERIOD = "sensision.scriptrunner.scanperiod";
-  
+
   public static final String SENSISION_JMX_POLLER = "sensision.jmx.poller";
-  public static final String SENSISION_POLLING_HINT = "sensision.polling.hint";  
+  public static final String SENSISION_POLLING_HINT = "sensision.polling.hint";
   public static final String SENSISION_POLLING_PERIOD = "sensision.polling.period";
   public static final String SENSISION_DUMP_PERIOD = "sensision.dump.period";
   public static final String SENSISION_DUMP_CURRENTTS = "sensision.dump.currentts";
@@ -154,30 +153,30 @@ public class Sensision {
   public static final String SENSISION_URLDEBUG = "sensision.urldebug";
 
   static Map<String,String> defaultLabels = new HashMap<String,String>();
-  
+
   static Double defaultLatitude = null;
   static Double defaultLongitude = null;
   static Long defaultElevation = null;
-  
+
   /**
    * Handy constants for empty labels
    */
   public static Map<String,String> EMPTY_LABELS = Collections.unmodifiableMap(new HashMap<String, String>());
-  
+
   static boolean disable = false;
-  
+
   static boolean useStringIntern = false;
-  
+
   /**
    * Number of time units per 'ms', defaults to 1000L.
    */
   public static long TIME_UNITS_PER_MS = 1000L;
-  
+
   static {
     //
     // Read config file if set. This will have the side effect of setting System properties
     //
-    
+
     if (null != System.getProperty(SENSISION_CONFIG_FILE)) {
       try {
         readConfigFile(System.getProperty(SENSISION_CONFIG_FILE));
@@ -185,9 +184,9 @@ public class Sensision {
         throw new RuntimeException(ioe);
       }
     }
-  
+
     instanceName = System.getProperty(SENSISION_INSTANCE);
-    
+
     // Extract time unit
     if (null != System.getProperty(SENSISION_TIME_UNIT)) {
       if ("us".equals(System.getProperty(SENSISION_TIME_UNIT))) {
@@ -198,29 +197,29 @@ public class Sensision {
         TIME_UNITS_PER_MS = 1L;
       }
     }
-    
+
     // Extract default labels
     if (null != System.getProperty(SENSISION_DEFAULT_LABELS)) {
       // Split on ','
-      
+
       String[] tokens = System.getProperty(SENSISION_DEFAULT_LABELS).trim().split(",");
-      
+
       for (String token: tokens) {
         // Split on '='
         if (!token.contains("=")) {
           throw new RuntimeException("Invalid default labels.");
         }
-        
+
         String[] subtokens = token.trim().split("=");
-        
+
         if (2 != subtokens.length) {
           throw new RuntimeException("Invalid default labels.");
         }
-        
+
         try {
           String name = URLDecoder.decode(subtokens[0], "UTF-8");
           String value = URLDecoder.decode(subtokens[1], "UTF-8");
-          
+
           if (defaultLabels.containsKey(name)) {
             throw new RuntimeException("Duplicate label '" + name + "' in default labels.");
           } else {
@@ -236,7 +235,7 @@ public class Sensision {
     if (null != System.getProperty(SENSISION_DEFAULT_LOCATION)) {
       try {
         defaultLatitude = Double.valueOf(System.getProperty(SENSISION_DEFAULT_LOCATION).replaceAll(":.*",""));
-        defaultLongitude = Double.valueOf(System.getProperty(SENSISION_DEFAULT_LOCATION).replaceAll(".*:",""));        
+        defaultLongitude = Double.valueOf(System.getProperty(SENSISION_DEFAULT_LOCATION).replaceAll(".*:",""));
       } catch (NumberFormatException nfe) {
         throw new RuntimeException(nfe);
       }
@@ -244,42 +243,42 @@ public class Sensision {
     // Extract default elevation
     if (null != System.getProperty(SENSISION_DEFAULT_ELEVATION)) {
       try {
-        defaultElevation = Long.valueOf(System.getProperty(SENSISION_DEFAULT_ELEVATION));    
+        defaultElevation = Long.valueOf(System.getProperty(SENSISION_DEFAULT_ELEVATION));
       } catch (NumberFormatException nfe) {
         throw new RuntimeException(nfe);
       }
     }
-    
+
     if (null != System.getProperty(Sensision.SENSISION_SERVER_PORT)) {
       server = new SensisionMetricsServer();
     } else {
       server = null;
     }
-    
+
     if (null != System.getProperty(Sensision.SENSISION_DUMP_PERIOD)) {
       dumper = new SensisionMetricsDumper();
     } else {
       dumper = null;
     }
-    
+
     if ("true".equals(System.getProperty(Sensision.SENSISION_DISABLE))) {
       disable = true;
     }
-    
+
     if ("true".equals(System.getProperty(Sensision.SENSISION_STRING_OPTIMIZE))) {
       useStringIntern = true;
     }
-    
+
     events = new String[Integer.parseInt(System.getProperty(Sensision.SENSISION_EVENTS_HISTORY, "0"))];
-    
+
     eventsDir = System.getProperty(Sensision.SENSISION_EVENTS_DIR);
-    
+
     eventsSuffix = System.getProperty(Sensision.SENSISION_EVENTS_SUFFIX);
-    
+
     //
     // Register a shutdown hook to flush the current events file
     //
-    
+
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
       public void run() {
@@ -290,12 +289,12 @@ public class Sensision {
       }
     });
   }
-  
+
   /**
    * Server to serve known metrics via HTTP
    */
   private static final SensisionMetricsServer server;
-  
+
   /**
    * Dumper to periodically dump known metrics
    */
@@ -305,41 +304,41 @@ public class Sensision {
    * Curator to clean expired values
    */
   private static final MetricsCurator curator = new MetricsCurator();
-  
+
   /**
    * Current sequence number of event
    */
   private static final AtomicLong eventSequence = new AtomicLong(-1);
-  
+
   /**
    * Circular array of events
    */
   private static final String[] events;
-  
+
   /**
    * Directory where events files should be created
    */
   private static final String eventsDir;
-  
+
   /**
    * Current File where events are stored
    */
   private static File eventsFile = null;
-  
+
   /**
    * Current Writer where events are stored
    */
   private static PrintWriter eventsWriter = null;
-  
+
   private static final String eventsSuffix;
-  
+
   /**
    * Name of Sensision instance
    */
   private static String instanceName = null;
-  
+
   public static final class Value {
-    
+
     /**
      * Possible types for a metric value
      */
@@ -349,47 +348,47 @@ public class Sensision {
      * Actual type of value
      */
     TYPE type = null;
-    
+
     /**
      * Class name
      */
     String cls;
-    
+
     /**
      * Labels
      */
     Map<String,String> labels;
-    
+
     /**
      * Timestamp of the value.
      */
     long timestamp;
-    
+
     /**
      * Optional latitude of value
-     */    
+     */
     Float latitude = null;
-    
+
     /**
      * Optional longitude of value
      */
     Float longitude = null;
-    
+
     /**
      * Optional elevation of value
      */
     Long elevation = null;
-    
+
     /**
      * Actual value. Class depends on type
      */
-    Object value;        
-    
+    Object value;
+
     /**
      * Optional expiration
      */
     Long expire;
-    
+
     protected Value() {}
     public Value(String name, Map<String,String> labels, long timestamp, Float latitude, Float longitude, Long elevation, Object value) {
       this.cls = name;
@@ -398,7 +397,7 @@ public class Sensision {
       this.latitude = latitude;
       this.longitude = longitude;
       this.elevation = elevation;
-      
+
       if (value instanceof Long || value instanceof Integer || value instanceof BigInteger) {
         this.type = TYPE.LONG;
         this.value = ((Number) value).longValue();
@@ -420,41 +419,41 @@ public class Sensision {
    * the ones which have expired.
    */
   private static final class MetricsCurator extends Thread {
-    
+
     private static final long DEFAULT_CURATION_PERIOD = 10000L;
-    
+
     private long period;
-    
+
     public MetricsCurator() {
       if (Sensision.disable) {
         return;
       }
-      
+
       if (null == System.getProperty(SENSISION_CURATION_PERIOD)) {
         return;
       }
-           
+
       try {
         period = Long.valueOf(System.getProperty(SENSISION_CURATION_PERIOD));
       } catch (NumberFormatException nfe) {
         period = DEFAULT_CURATION_PERIOD;
       }
-     
+
       this.setDaemon(true);
       this.setName("[Sensision MetricsCurator (" + period + ")]");
       this.start();
     }
-    
+
     @Override
     public void run() {
       //
       // Periodically scan the metrics and remove expired ones
       //
-      
+
       while(true) {
         try {
           Thread.sleep(period);
-        } catch (InterruptedException ie) {          
+        } catch (InterruptedException ie) {
         }
 
         if (null == values) {
@@ -473,16 +472,16 @@ public class Sensision {
       }
     }
   }
-  
-  
+
+
   /**
    * Map of class name to map of label values to metric value.
    */
   private static Map<String, Map<Map<String,String>, Value>> values = new ConcurrentHashMap<String, Map<Map<String,String>,Value>>();
-   
+
   /**
    * Set the value, location and elevation of the given metric (class + labels).
-   * 
+   *
    *  @param cls Name of the metrics class
    *  @param labels Map of labels uniquely qualifying the metric in its class
    *  @param ts Timestamp of the value, in microseconds since the Epoch
@@ -493,19 +492,19 @@ public class Sensision {
    *  @param ttl Time to live of the metric. If the next update does not occur within this number of milliseconds, the metric will be discarded - null if no ttl
    */
   public static synchronized final void set(String cls, Map<String,String> labels, long ts, Float latitude, Float longitude, Long elevation, Object value, Long ttl) {
-    
+
     if (Sensision.disable) {
       return;
     }
-    
+
     //
     // Check that class name and labels are all non null
     //
-    
+
     if (null == cls) {
       throw new RuntimeException("Invalid null class name for metric");
     }
-    
+
     if (labels.containsKey(null) || labels.containsValue(null)) {
       throw new RuntimeException("Invalid null label for metric " + cls + labels);
     }
@@ -515,18 +514,18 @@ public class Sensision {
     // CAUTION: we do not synchronize call, so we might overwrite an ongoing first update
     // if they occur at very high frequency
     //
-    
+
     Value container = getContainer(cls, labels, value);
 
-    // null container means we actually removed a Value so return immediately    
+    // null container means we actually removed a Value so return immediately
     if (null == container) {
       return;
     }
-    
+
     //
     // Check value type
     //
-    
+
     if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof Byte || value instanceof BigInteger) {
       if (null != container.type && Value.TYPE.LONG != container.type) {
         throw new RuntimeException("Invalid value type for " + cls + labels + ", was " + container.type + ", is now LONG");
@@ -562,15 +561,15 @@ public class Sensision {
       if (null == container.value) {
         container.type = Value.TYPE.STRING;
       }
-      container.value = (String) value;      
+      container.value = (String) value;
     } else {
-      throw new RuntimeException("Invalid value type (" + value.getClass() + ") for metric " + cls + labels);       
+      throw new RuntimeException("Invalid value type (" + value.getClass() + ") for metric " + cls + labels);
     }
 
     //
     // Set location/elevation
     //
-    
+
     container.latitude = latitude;
     container.longitude = longitude;
     container.elevation = elevation;
@@ -578,9 +577,9 @@ public class Sensision {
     //
     // Force timestamp
     //
-    
+
     container.timestamp = ts;
-    
+
     if (null != ttl) {
       container.expire = System.currentTimeMillis() + ttl;
     } else {
@@ -590,16 +589,16 @@ public class Sensision {
 
   private static Map<String,String> labelsToMap(String... labels) {
     Map<String,String> labelsmap = new HashMap<String,String>();
-    
+
     if (null != labels) {
       for (int i = 0; i < labels.length / 2; i++) {
         labelsmap.put(labels[i * 2], labels[i * 2 + 1]);
       }
     }
-    
+
     return labelsmap;
   }
-  
+
   public static final void set(String cls, Map<String,String> labels, Object value) {
     set(cls, labels, System.currentTimeMillis() * TIME_UNITS_PER_MS, null, null, null, value, null);
   }
@@ -611,31 +610,31 @@ public class Sensision {
   //
   // Versions of 'set' with an array of labels as parameter
   //
-  
-  public static final void set(String cls, long ts, Float latitude, Float longitude, Long elevation, Object value, Long ttl, String... labels) {    
+
+  public static final void set(String cls, long ts, Float latitude, Float longitude, Long elevation, Object value, Long ttl, String... labels) {
     set(cls, labelsToMap(labels), ts, latitude, longitude, elevation, value, ttl);
   }
-  
+
   public static final void set(String cls, Object value, String... labels) {
     set(cls, labelsToMap(labels), value);
-  }  
-  
+  }
+
   /**
    * Remove a metric container
-   * 
+   *
    * @param cls Class of metric
    * @param labels Labels for the metric
-   * 
+   *
    * @return true if there was a container to remove, false otherwise
    */
   public static synchronized final boolean clear(String cls, Map<String,String> labels) {
     Value container = getContainer(cls, labels, null);
     return null != container;
   }
-  
+
   /**
    * Update a numerical metric with a numerical delta
-   * 
+   *
    * @param cls Name of metric class
    * @param labels Labels of metric
    * @param ts Timestamp of update in microseconds since the epoch
@@ -649,15 +648,15 @@ public class Sensision {
     if (Sensision.disable) {
       return;
     }
-    
+
     //
     // Check that class name and labels are all non null
     //
-    
+
     if (null == cls) {
       throw new RuntimeException("Invalid null class name for metric");
     }
-    
+
     if (labels.containsKey(null) || labels.containsValue(null)) {
       throw new RuntimeException("Invalid null label for metric " + cls + labels);
     }
@@ -667,20 +666,20 @@ public class Sensision {
     // CAUTION: we do not synchronize call, so we might overwrite an ongoing first update
     // if they occur at very high frequency
     //
-    
+
     Value container = getContainer(cls, labels, delta);
-    
+
     // null container means we actually removed a Value so return immediately
     if (null == container) {
       return;
     }
-    
+
     //
     // Check value type
     //
-    
+
     if (Value.TYPE.LONG == container.type) {
-      ((AtomicLong) container.value).addAndGet(((Number) delta).longValue());      
+      ((AtomicLong) container.value).addAndGet(((Number) delta).longValue());
     } else if (Value.TYPE.DOUBLE == container.type) {
       ((AtomicLong) container.value).set(Double.doubleToRawLongBits(((Number) delta).doubleValue() + Double.longBitsToDouble(((AtomicLong) container.value).get())));
     } else if (null == container.type) {
@@ -692,13 +691,13 @@ public class Sensision {
         container.value = new AtomicLong(Double.doubleToRawLongBits(((Number) delta).doubleValue()));
       }
     } else {
-      throw new RuntimeException("Can only update metrics of type LONG or DOUBLE (" + cls + labels + ")");       
+      throw new RuntimeException("Can only update metrics of type LONG or DOUBLE (" + cls + labels + ")");
     }
-    
+
     //
     // Set location/elevation
     //
-    
+
     container.latitude = latitude;
     container.longitude = longitude;
     container.elevation = elevation;
@@ -706,9 +705,9 @@ public class Sensision {
     //
     // Force timestamp
     //
-    
-    container.timestamp = ts;    
-    
+
+    container.timestamp = ts;
+
     if (null != ttl) {
       container.expire = System.currentTimeMillis() + ttl;
     }
@@ -717,73 +716,73 @@ public class Sensision {
   public static final void update(String cls, Map<String,String> labels, Long ttl, Number delta) {
     update(cls, labels, System.currentTimeMillis() * TIME_UNITS_PER_MS, null, null, null, delta, ttl);
   }
-  
+
   public static final void update(String cls, Map<String,String> labels, Number delta) {
     update(cls, labels, System.currentTimeMillis() * TIME_UNITS_PER_MS, null, null, null, delta, null);
   }
-  
+
   //
   // Versions of 'update' with an array of labels as parameter
   //
-  
-  public static final void update(String cls, long ts, Float latitude, Float longitude, Long elevation, Number delta, Long ttl, String... labels) { 
+
+  public static final void update(String cls, long ts, Float latitude, Float longitude, Long elevation, Number delta, Long ttl, String... labels) {
     update(cls, labelsToMap(labels), ts, latitude, longitude, elevation, delta, ttl);
   }
 
   public static final void update(String cls, Number delta, String... labels) {
     update(cls, labelsToMap(labels), delta);
   }
-  
+
   public static final void event(String cls, Map<String,String> labels, Object value) {
     event(System.currentTimeMillis() * TIME_UNITS_PER_MS, Double.NaN, Double.NaN, null, cls, labels, value);
   }
-  
+
   /**
    * Store an event. We do not use a synchronized method, which means that if the rate of events is very important
    * we might overwrite an event with an older one if the older one was longer to encode.
-   * 
+   *
    * This is a risk we tolerate for now.
    */
   public static final void event(Long ts, Double latitude, Double longitude, Long elevation, String cls, Map<String,String> labels, Object value) {
-    
+
     // Do nothing if we do not keep track of events
     if ((0 == events.length || null == value) && null == eventsDir) {
       return;
     }
-    
+
     //
     // Increment event sequence
     //
-    
+
     long seqno = eventSequence.addAndGet(1L);
-        
+
     //
     // Build event
     //
 
     StringBuilder sb = buildEvent(ts, latitude, longitude, elevation, cls, labels, value);
-    
+
     //
     // Store event on disk
     //
-    
+
     storeEvent(sb);
-    
+
     //
     // Store event in history
     //
-    
+
     if (events.length > 0) {
       //
       // Compute array index
       //
-      
+
       int idx = (int) (seqno % (long) events.length);
 
       events[idx] = sb.toString();
     }
   }
-  
+
   private static void storeEvent(StringBuilder sb) {
     try {
       if (null == eventsDir) {
@@ -791,17 +790,17 @@ public class Sensision {
       }
       synchronized(eventsDir) {
         File root = new File(eventsDir);
-        
+
         if (!root.exists() || !root.isDirectory()) {
           return;
         }
-        
+
         if (null == eventsFile) {
           String now = Long.toHexString(Long.MAX_VALUE - System.currentTimeMillis());
           String uuid = UUID.randomUUID().toString();
           // End the name with a '.' so even if eventsSuffix is SENSISION_METRICS_SUFFIX it won't bother
           eventsFile = new File(new File(eventsDir), now + "." + uuid + (null != eventsSuffix ? ("." + eventsSuffix) : ""));
-          
+
           try {
             eventsWriter = new PrintWriter(eventsFile);
           } catch (FileNotFoundException fnfe) {
@@ -821,7 +820,7 @@ public class Sensision {
       e.printStackTrace();
     }
   }
-  
+
   public static void flushEvents() {
     if (null == eventsDir) {
       return;
@@ -835,44 +834,44 @@ public class Sensision {
       eventsWriter = null;
     }
   }
-  
+
   public static boolean onDisk() {
     return null != eventsDir;
   }
-  
+
   private static StringBuilder buildEvent(Long ts, Double latitude, Double longitude, Long elevation, String cls, Map<String,String> labels, Object value) {
     //
     // Build representation of event
     //
-    
+
     StringBuilder sb = new StringBuilder();
-    
+
     if (null != ts) {
       sb.append(ts);
     } else {
       sb.append(System.currentTimeMillis() * TIME_UNITS_PER_MS);
     }
-    
+
     sb.append("/");
-    
+
     if (null != latitude && null != longitude && Double.isFinite(latitude) && Double.isFinite(longitude)) {
       sb.append(latitude);
       sb.append(":");
       sb.append(longitude);
     }
-    
+
     sb.append("/");
-    
+
     if (null != elevation) {
       sb.append(elevation);
     }
-    
+
     sb.append(" ");
-    
+
     metadataToString(sb, cls, labels);
-    
+
     sb.append(" ");
-    
+
     if (value instanceof Number) {
       sb.append(value);
     } else if (value instanceof Boolean) {
@@ -886,7 +885,7 @@ public class Sensision {
       encodeName(sb, value.toString());
       sb.append("'");
     }
-    
+
     return sb;
   }
   public static void encodeName(StringBuilder sb, String name) {
@@ -895,15 +894,15 @@ public class Sensision {
     }
     try {
       sb.append(URLEncoder.encode(name, "UTF-8").replaceAll("\\{", "%7B").replaceAll("\\}", "%7D").replaceAll(",", "%2C").replaceAll("\\+", "%20"));
-    } catch (UnsupportedEncodingException uee) {      
+    } catch (UnsupportedEncodingException uee) {
     }
   }
-  
+
   public static void metadataToString(StringBuilder sb, String name, Map<String,String> labels) {
     encodeName(sb, name);
     sb.append("{");
     boolean first = true;
-    
+
     for (Entry<String, String> entry: labels.entrySet()) {
       if (!first) {
         sb.append(",");
@@ -918,7 +917,7 @@ public class Sensision {
 
   /**
    * Return the current value of the given Geo Time Series.
-   * 
+   *
    * @param cls Class name of GTS
    * @param labels Labels map of GTS
    * @return the current value of the GTS or null if the GTS is unknown
@@ -929,11 +928,11 @@ public class Sensision {
       return null;
     }
     Value container = clsValues.get(labels);
-    
+
     if (null == container) {
       return null;
     }
-    
+
     switch(container.type) {
       case BOOLEAN:
         return container.value;
@@ -950,7 +949,7 @@ public class Sensision {
 
   /**
    * Return the current location of the given Geo Time Series.
-   * 
+   *
    * @param cls Class name of GTS
    * @param labels Labels map of GTS
    * @return an array of 2 floats (latitude, longitude) or null if either the GTS is unknown or the location undefined
@@ -961,7 +960,7 @@ public class Sensision {
       return null;
     }
     Value container = clsValues.get(labels);
-    
+
     if (null == container) {
       return null;
     }
@@ -969,17 +968,17 @@ public class Sensision {
     if (null == container.latitude || null == container.longitude) {
       return null;
     }
-    
+
     float[] latlon = new float[2];
     latlon[0] = container.latitude;
     latlon[1] = container.longitude;
-    
+
     return latlon;
   }
 
   /**
    * Return the current elevation of the given Geo Time Series.
-   * 
+   *
    * @param cls Class name of GTS
    * @param labels Labels map of GTS
    * @return the set elevation or null if either the GTS is unknown or the elevation undefined
@@ -990,7 +989,7 @@ public class Sensision {
       return null;
     }
     Value container = clsValues.get(labels);
-    
+
     if (null == container) {
       return null;
     }
@@ -1000,7 +999,7 @@ public class Sensision {
 
   /**
    * Return the current timestamp of the given Geo Time Series.
-   * 
+   *
    * @param cls Class name of GTS
    * @param labels Labels map of GTS
    * @return the set timestamp or null if the GTS is unknown
@@ -1011,7 +1010,7 @@ public class Sensision {
       return null;
     }
     Value container = clsValues.get(labels);
-    
+
     if (null == container) {
       return null;
     }
@@ -1022,7 +1021,7 @@ public class Sensision {
   private synchronized static final Value getContainer(String cls, Map<String,String> labels, Object value) {
 
     Value container = null;
-    
+
     Map<Map<String,String>, Value> clsValues = values.get(cls);
 
     if (null == value) {
@@ -1040,11 +1039,11 @@ public class Sensision {
       container = new Value();
       // Make a clean copy of labels
       Map<String,String> lbls = new HashMap<String, String>();
-      
+
       //
       // Copy labels using String#intern if instructed to optimize strings
       //
-      
+
       if (!useStringIntern) {
         lbls.putAll(labels);
       } else {
@@ -1056,148 +1055,148 @@ public class Sensision {
       container.labels = lbls;
       values.get(cls).put(lbls, container);
     } else {
-      container = clsValues.get(labels);      
+      container = clsValues.get(labels);
       if (null == container) {
         container = new Value();
         // Make a clean copy of labels
         Map<String,String> lbls = new HashMap<String, String>();
-        
+
         //
         // Copy labels using String#intern if instructed to optimize strings
         //
-        
+
         if (!useStringIntern) {
           lbls.putAll(labels);
         } else {
           for (Entry<String,String> entry: labels.entrySet()) {
             lbls.put(entry.getKey().intern(), entry.getValue().intern());
-          }          
+          }
         }
         container.cls = cls;
         container.labels = lbls;
         values.get(cls).put(lbls, container);
       }
     }
-    
+
     return container;
   }
-  
+
   /**
    * Parses a metric line into a Value instance.
-   * 
+   *
    * @param str
    * @return The parsed Value or null if a parse error occurred.
    */
   private static final Pattern MEASUREMENT_RE = Pattern.compile("^([0-9]+)?/(([0-9.-]+):([0-9.-]+))?/([0-9-]+)? +([^ ]+)\\{([^\\}]*)\\} +(.+)$");
-  
+
   public static final Value parseMetric(String str) {
     Matcher matcher = MEASUREMENT_RE.matcher(str);
-    
+
     if (!matcher.matches()) {
       return null;
     }
-    
+
     //
     // Check name
     //
-    
+
     String name = matcher.group(6);
-    
+
     if (name.contains("%")) {
-      try {      
+      try {
         name = URLDecoder.decode(name, "UTF-8");
       } catch (UnsupportedEncodingException uee) {
         // Can't happen, we're using UTF-8
-      }      
+      }
     }
-    
+
     //
     // Parse labels.
     // We use a TreeMap so labels will be sorted, which is needed for the DeduplicationManager
     //
-    
+
     Map<String,String> labels = new TreeMap<String,String>();
-    
+
     // Split on ','
     String[] tokens = matcher.group(7).split(",");
-    
+
     for (String token: tokens) {
       // Skip empty token
       if ("".equals(token)) {
         continue;
       }
-      
+
       String[] subtokens = token.split("=");
-      
+
       //
       // Ignore labels if there is more than 1 equal sign
       //
-      
+
       if (subtokens.length > 2) {
         continue;
       }
-      
+
       try {
         String lname = URLDecoder.decode(subtokens[0], "UTF-8");
         String lvalue = subtokens.length > 1 ? URLDecoder.decode(subtokens[1], "UTF-8") : "";
-      
+
         labels.put(lname, lvalue);
       } catch (UnsupportedEncodingException uee) {
         // Can't happen, we're using UTF-8 which is one of the 6 standard JVM charsets
       }
     }
-    
+
     //
     // Extract timestamp, optional location and elevation
     //
-    
+
     Long timestamp = null;
     Float latitude = null;
     Float longitude = null;
     Long elevation = null;
-    
+
     try {
-      
+
       if (null != matcher.group(1)) {
         timestamp = Long.valueOf(matcher.group(1));
       } else {
         // Use a beacon value if timestamp was not specified
         timestamp = Long.MIN_VALUE;
       }
-      
+
       if (null != matcher.group(2)) {
         latitude = Float.valueOf(matcher.group(3));
         longitude = Float.valueOf(matcher.group(4));
       }
-      
+
       if (null != matcher.group(5)) {
         elevation = Long.valueOf(matcher.group(5));
-      }      
+      }
     } catch (NumberFormatException nfe) {
       return null;
     }
-    
+
     //
     // Extract value
     //
-        
+
     String valuestr = matcher.group(8);
 
     Object value = parseValue(valuestr);
-      
+
     if (null == value) {
       return null;
     }
 
     Value v = new Value(name, labels, timestamp, latitude, longitude, elevation, value);
-    
+
     return v;
   }
 
   private static final Pattern STRING_VALUE_RE = Pattern.compile("^['\"].*['\"]$");
   private static final Pattern BOOLEAN_VALUE_RE = Pattern.compile("^(T|F|true|false)$", Pattern.CASE_INSENSITIVE);
   private static final Pattern LONG_VALUE_RE = Pattern.compile("^[+-]?[0-9]+$");
-  private static final Pattern DOUBLE_VALUE_RE = Pattern.compile("^[+-]?([0-9]+)\\.([0-9]+)(E\\-?[0-9]+)?$");  
+  private static final Pattern DOUBLE_VALUE_RE = Pattern.compile("^[+-]?([0-9]+)\\.([0-9]+)(E\\-?[0-9]+)?$");
 
   /**
    * Parses a value. This methode is borrowed from continuum's GTSHelper#parseValue
@@ -1205,16 +1204,16 @@ public class Sensision {
    * @return
    */
   public static Object parseValue(String valuestr) {
-    
+
     Object value;
-    
+
     Matcher valuematcher = DOUBLE_VALUE_RE.matcher(valuestr);
 
     if (valuematcher.matches()) {
       // FIXME(hbs): maybe find a better heuristic to determine if we should
       // create a BigDecimal or a Double. BigDecimal is only meaningful if its encoding
       // will be less than 8 bytes.
-      
+
       //value = Double.valueOf(valuestr);
       if (valuematcher.group(1).length() < 10 && valuematcher.group(2).length() < 10 && null == valuematcher.group(3)) {
         value = new BigDecimal(valuestr);
@@ -1223,17 +1222,17 @@ public class Sensision {
       }
     } else {
       valuematcher = LONG_VALUE_RE.matcher(valuestr);
-      
+
       if (valuematcher.matches()) {
         value = Long.valueOf(valuestr);
       } else {
         valuematcher = STRING_VALUE_RE.matcher(valuestr);
-        
+
         if (valuematcher.matches()) {
           value = valuestr.substring(1, valuestr.length() - 1);
         } else {
           valuematcher = BOOLEAN_VALUE_RE.matcher(valuestr);
-          
+
           if (valuematcher.matches()) {
             if (valuestr.startsWith("t") || valuestr.startsWith("T")) {
               value = Boolean.TRUE;
@@ -1246,66 +1245,67 @@ public class Sensision {
         }
       }
     }
-    
+
     return value;
   }
 
-  
+
   /**
    * Dump last values of all known metrics onto the given PrintWriter.
-   * 
+   *
    * @param out PrintWriter instance to write to.
    * @param useValueTimestamp Whether or not we should use the timestamp associated with the value
+   * @param openmetrics Output metrics in OpenMetrics format
    * @throws IOException
    */
-  public static final void dump(PrintWriter out, boolean useValueTimestamp) throws IOException {
+  public static final void dump(PrintWriter out, boolean useValueTimestamp, boolean openmetrics) throws IOException {
     List<String> classes = new ArrayList<String>(values.keySet());
-    
+
     for (String clazz: classes) {
       Map<Map<String,String>,Value> byClass = values.get(clazz);
-      
+
       if (null == byClass) {
         continue;
       }
-      
-      List<Value> vals = new ArrayList<Value>(byClass.values()); 
+
+      List<Value> vals = new ArrayList<Value>(byClass.values());
       for (Value value: vals) {
-        dumpValue(out, value, useValueTimestamp, true);
+        dumpValue(out, value, useValueTimestamp, true, openmetrics);
       }
     }
-    
+
     //
     // Now dump external providers
     //
-    
+
     for (Iterable<Value> provider: providers) {
       if (null == provider) {
         continue;
       }
-      
+
       Iterator<Value> iterator = provider.iterator();
-      
+
       if (null == iterator) {
         continue;
       }
-      
+
       while(iterator.hasNext()) {
-        dumpValue(out, iterator.next(), useValueTimestamp, true);
+        dumpValue(out, iterator.next(), useValueTimestamp, true, openmetrics);
       }
     }
   }
 
   public static final void dump(PrintWriter out) throws IOException {
-    dump(out, true);
+    dump(out, true, false);
   }
 
   /**
    * Dump the current values of metrics in the events file
-   * 
+   *
    * @param useValueTimestamp
    * @throws IOException
    */
-  public static final void dumpAsEvents(boolean useValueTimestamp) throws IOException {    
+  public static final void dumpAsEvents(boolean useValueTimestamp) throws IOException {
     if (null == eventsDir) {
       return;
     }
@@ -1314,28 +1314,28 @@ public class Sensision {
       // Ensure we have a writer
       //
       storeEvent(null);
-      
+
       if (null != eventsWriter) {
-        dump(eventsWriter, useValueTimestamp);
+        dump(eventsWriter, useValueTimestamp, false);
       }
     }
   }
 
   /**
    * Outputs a value on a PrintWriter
-   * 
+   *
    * @param out PrintWriter to use
    * @param value Value instance to display
    * @param useValueTimestamp flag indicating whether or not we consider the Value ts or 'now'
    * @throws IOException
    */
-  public static final void dumpValue(PrintWriter out, Value value, boolean useValueTimestamp, boolean crlf) throws IOException {
+  public static final void dumpValue(PrintWriter out, Value value, boolean useValueTimestamp, boolean crlf, boolean openmetrics) throws IOException {
     Object v = null;
 
     switch(value.type) {
       case LONG:
         if (value.value instanceof AtomicLong) {
-          v = ((AtomicLong) value.value).longValue();          
+          v = ((AtomicLong) value.value).longValue();
         } else {
           v = ((Number) value.value).longValue();
         }
@@ -1352,17 +1352,22 @@ public class Sensision {
         v = value.value;
         break;
     }
-    dumpValue(out, value.cls, value.labels, useValueTimestamp ? value.timestamp : System.currentTimeMillis() * TIME_UNITS_PER_MS, value.latitude, value.longitude, value.elevation, v, crlf);
+    dumpValue(out, value.cls, value.labels, useValueTimestamp ? value.timestamp : System.currentTimeMillis() * TIME_UNITS_PER_MS, value.latitude, value.longitude, value.elevation, v, crlf, openmetrics);
   }
 
   private static final void dumpValue(PrintWriter out, Value value) throws IOException {
-    dumpValue(out, value, true, true);
+    dumpValue(out, value, true, true, false);
   }
-  
-  private static final void dumpValue(PrintWriter out, String name, Map<String,String> labels, long timestamp, Float latitude, Float longitude, Long elevation, Object value, boolean crlf) throws IOException {
+
+  private static final void dumpValue(PrintWriter out, String name, Map<String,String> labels, long timestamp, Float latitude, Float longitude, Long elevation, Object value, boolean crlf, boolean openmetrics) throws IOException {
     if (null == out) {
       return;
     }
+    if (openmetrics) {
+      OpenMetrics.dump(out, name, labels, timestamp, value);
+      return;
+    }
+
     if (Long.MIN_VALUE != timestamp) {
       out.print(timestamp);
     }
@@ -1374,7 +1379,7 @@ public class Sensision {
     } else if (null != defaultLatitude && null != defaultLongitude) {
       out.print(defaultLatitude);
       out.print(":");
-      out.print(defaultLongitude);          
+      out.print(defaultLongitude);
     }
     out.print("/");
     if (null != elevation) {
@@ -1397,7 +1402,7 @@ public class Sensision {
         out.print(URLEncoder.encode(label, "UTF-8").replaceAll("\\{", "%7B").replaceAll("\\}", "%7D").replaceAll(",", "%2C").replaceAll("\\+", "%20"));
         out.print("=");
         out.print(URLEncoder.encode(defaultLabels.get(label), "UTF-8").replaceAll("\\{", "%7B").replaceAll("\\}", "%7D").replaceAll(",", "%2C").replaceAll("\\+", "%20"));
-        first = false;            
+        first = false;
       }
     }
     for (String label: labels.keySet()) {
@@ -1412,53 +1417,53 @@ public class Sensision {
     out.print("}");
     out.print(" ");
     if (value instanceof Long || value instanceof Integer || value instanceof BigInteger) {
-      out.print(((Number) value).longValue());      
+      out.print(((Number) value).longValue());
     } else if (value instanceof Double || value instanceof Float || value instanceof BigDecimal) {
       out.print(((Number) value).doubleValue());
     } else if (value instanceof String) {
       out.print("'");
       out.print(URLEncoder.encode((String) value, "UTF-8").replaceAll("'", "%27").replaceAll("\\+", "%20"));
       out.print("'");
-    } else if (value instanceof Boolean) {      
+    } else if (value instanceof Boolean) {
       if (Boolean.TRUE.equals(value)) {
         out.print("T");
       } else {
         out.print("F");
       }
     }
-    if (crlf) { 
+    if (crlf) {
       out.print("\r\n");
     }
   }
-  
+
   public static String getUUID() {
     return uuid;
   }
-  
+
   public static long getStartTime() {
     return starttime;
   }
-  
+
   public static File getHomeDir() {
     return new File(System.getProperty(Sensision.SENSISION_HOME, Sensision.DEFAULT_SENSISION_HOME));
   }
-  
+
   public static File getQueueDir() {
     return new File(getHomeDir(), Sensision.SENSISION_QUEUE_SUBDIR);
   }
-  
+
   public static File getMetricsDir() {
     return new File(getHomeDir(), Sensision.SENSISION_METRICS_SUBDIR);
   }
-  
+
   public static File getTargetsDir() {
     return new File(getHomeDir(), Sensision.SENSISION_TARGETS_SUBDIR);
   }
-  
+
   public static Pattern getTargetPattern() {
     return SENSISION_TARGET_PATTERN;
   }
-  
+
   public static void addDefaultLocation(StringBuilder sb) {
     if (null != defaultLatitude && null != defaultLongitude) {
       sb.append(defaultLatitude);
@@ -1466,98 +1471,98 @@ public class Sensision {
       sb.append(defaultLongitude);
     }
   }
-  
+
   public static void addDefaultElevation(StringBuilder sb) {
     if (null != defaultElevation) {
       sb.append(defaultElevation);
     }
   }
-  
+
   public static void addValueProvider(Iterable<Value> provider) {
     providers.add(provider);
   }
-  
+
   public static void removeValueProvider(Iterable<Value> provider) {
     providers.remove(provider);
   }
-  
+
   /**
    * Read a property file and return a Properties instance and set System properties accordingly
-   * 
+   *
    * @param name
    * @return
    * @throws IOException
    */
   public static Properties readConfigFile(String name) throws IOException {
-    
+
     //
     // Read the configuration
     //
-    
+
     BufferedReader br = new BufferedReader(new FileReader(name));
-    
+
     Properties props = new Properties();
 
     try {
-      
+
       int lineno = 0;
-      
+
       while (true) {
         String line = br.readLine();
-        
+
         if (null == line) {
           break;
         }
-      
+
         lineno++;
         line = line.trim();
-        
+
         if ("".equals(line) || line.startsWith("#") || line.startsWith("//") || line.startsWith("--")) {
           continue;
         }
-        
+
         if (!line.contains("=")) {
           throw new IOException("Syntax error on line " + lineno);
         }
-        
+
         String key = line.replaceAll("^([^=]+)=.*$", "$1").trim();
         String value = line.replaceAll("^([^=]+)=", "").trim();
-        
+
         props.setProperty(key, value);
-        
+
         //
         // Copy k/v to system properties or override the read value with system property
         //
-        
+
         if (null == System.getProperty(key)) {
           System.setProperty(key, value);
         } else {
           props.setProperty(key, System.getProperty(key));
         }
-      }      
+      }
     } finally {
       if (null != br) { try { br.close(); } catch (Exception e) {} }
     }
 
     return props;
   }
-  
+
   public static long getCurrentEvent() {
     return eventSequence.get();
   }
-  
+
   public static List<String> getEvents() {
     return Collections.unmodifiableList(Arrays.asList(events));
   }
-  
+
   public static void setInstance(String name) {
     instanceName = name;
   }
-  
+
   public static String getInstance() {
     return instanceName;
   }
-  
+
   public static long getTimeUnitsPerMs() {
     return TIME_UNITS_PER_MS;
   }

--- a/sensision/src/main/java/io/warp10/sensision/Sensision.java
+++ b/sensision/src/main/java/io/warp10/sensision/Sensision.java
@@ -74,8 +74,6 @@ public class Sensision {
   public static final String SENSISION_POLLERS = "sensision.pollers";
   public static final String SENSISION_HTTP_TOKEN_HEADER_DEFAULT = "X-Warp10-Token";
 
-  public static final String SENSISION_OPENMETRICS = "sensision.openmetrics";
-
   public static final String HTTP_HEADER_UUID = "X-UUID";
   public static final String HTTP_HEADER_TIMESTAMP = "X-Timestamp";
   public static final String HTTP_HEADER_LASTEVENT = "X-Sensision-LastEvent";

--- a/sensision/src/main/java/io/warp10/sensision/SensisionFileJMXAgent.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionFileJMXAgent.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/sensision/src/main/java/io/warp10/sensision/SensisionFileJMXAgent.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionFileJMXAgent.java
@@ -21,18 +21,18 @@ import java.io.PrintWriter;
 import java.lang.instrument.Instrumentation;
 
 public class SensisionFileJMXAgent extends SensisionJMXPoller {
-  
+
   private final SensisionMetricsDumper dumper;
-  
+
   public SensisionFileJMXAgent(String agentArgs, Instrumentation instrumentation) {
     super(agentArgs, instrumentation);
     final SensisionFileJMXAgent self = this;
-    
-    dumper = new SensisionMetricsDumper() {      
+
+    dumper = new SensisionMetricsDumper() {
       @Override
       public void dump(PrintWriter out) throws IOException {
-        self.dump(out);
+        self.dump(out, false);
       }
     };
-  }    
+  }
 }

--- a/sensision/src/main/java/io/warp10/sensision/SensisionHttpJMXAgent.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionHttpJMXAgent.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2021  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class SensisionHttpJMXAgent extends SensisionJMXPoller {
     dumper = new SensisionMetricsServer() {
       @Override
       public void dumpMetrics(PrintWriter out, boolean useValueTimestamp, boolean openmetrics) throws IOException {
-        self.dump(out);
+        self.dump(out, OpenMetrics.useOpenMetrics());
       }
     };
   }

--- a/sensision/src/main/java/io/warp10/sensision/SensisionHttpJMXAgent.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionHttpJMXAgent.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2022  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class SensisionHttpJMXAgent extends SensisionJMXPoller {
     dumper = new SensisionMetricsServer() {
       @Override
       public void dumpMetrics(PrintWriter out, boolean useValueTimestamp, boolean openmetrics) throws IOException {
-        self.dump(out, OpenMetrics.useOpenMetrics());
+        self.dump(out, openmetrics);
       }
     };
   }

--- a/sensision/src/main/java/io/warp10/sensision/SensisionHttpJMXAgent.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionHttpJMXAgent.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -21,18 +21,18 @@ import java.io.PrintWriter;
 import java.lang.instrument.Instrumentation;
 
 public class SensisionHttpJMXAgent extends SensisionJMXPoller {
-  
+
   private final SensisionMetricsServer dumper;
-  
+
   public SensisionHttpJMXAgent(String agentArgs, Instrumentation instrumentation) {
     super(agentArgs, instrumentation);
     final SensisionHttpJMXAgent self = this;
-    
-    dumper = new SensisionMetricsServer() {      
+
+    dumper = new SensisionMetricsServer() {
       @Override
-      public void dumpMetrics(PrintWriter out, boolean useValueTimestamp) throws IOException {
+      public void dumpMetrics(PrintWriter out, boolean useValueTimestamp, boolean openmetrics) throws IOException {
         self.dump(out);
       }
     };
-  }    
+  }
 }

--- a/sensision/src/main/java/io/warp10/sensision/SensisionJMXPoller.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionJMXPoller.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -53,19 +53,19 @@ import javax.management.openmbean.TabularData;
  * Java Agent which reads JMX MBeans and produces Sensision metrics accordingly
  */
 public class SensisionJMXPoller {
-  
+
   private static final String SENSISION_JMX_METRICS_PREFIX = "jmx.";
-  
+
   /**
    * Array of patterns to match MBean classes which should be included
    */
   private Pattern[] includedMBeans;
-  
+
   /**
    * Array of patterns to match MBean classes which should be excluded
    */
   private Pattern[] excludedMBeans;
-  
+
   /**
    * Array of patterns to match name of metrics which should be included
    */
@@ -75,28 +75,28 @@ public class SensisionJMXPoller {
    * Array of patterns to match name of metrics which should be excluded
    */
   private Pattern[] excludedMetrics;
-  
+
   public SensisionJMXPoller(String agentArgs, Instrumentation instrumentation) {
     String[] tokens = null;
-    
+
     if (null != agentArgs) {
       tokens = agentArgs.split(":");
     } else {
       tokens = new String[0];
     }
-    
+
     for (String token: tokens) {
       if (token.startsWith("metrics=")) {
         String[] subtokens = token.substring(8).split(",");
-        
+
         includedMetrics = new Pattern[subtokens.length];
         excludedMetrics = new Pattern[subtokens.length];
-        
+
         int i = 0;
         for (String subtoken: subtokens) {
           try {
             subtoken = URLDecoder.decode(subtoken, "UTF-8");
-          } catch (UnsupportedEncodingException uee) {            
+          } catch (UnsupportedEncodingException uee) {
           }
           if (subtoken.startsWith("!")) {
             // Skip slot in includedMetrics as this subtoken is an exclusion
@@ -123,16 +123,16 @@ public class SensisionJMXPoller {
         }
       } else if (token.startsWith("mbeans=")) {
         String[] subtokens = token.substring(7).split(",");
-        
+
         includedMBeans = new Pattern[subtokens.length];
         excludedMBeans = new Pattern[subtokens.length];
-        
+
         int i = 0;
-        
+
         for (String subtoken: subtokens) {
           try {
             subtoken = URLDecoder.decode(subtoken, "UTF-8");
-          } catch (UnsupportedEncodingException uee) {            
+          } catch (UnsupportedEncodingException uee) {
           }
           if (subtoken.startsWith("!")) {
             // Skip slot in includedMBeans as this subtoken is an exclusion
@@ -161,15 +161,15 @@ public class SensisionJMXPoller {
       }
     }
   }
-  
+
   private boolean checkPatterns(String value, Pattern[] included, Pattern[] excluded) {
-    
+
     if (null == included || null == excluded) {
       return true;
     }
-    
+
     boolean hasIncludes = false;
-    
+
     for (int i = 0; i < included.length; i++) {
       if (null != included[i]) {
         hasIncludes = true;
@@ -183,75 +183,75 @@ public class SensisionJMXPoller {
         }
       }
     }
-    
+
     // If there were some include clauses, return false if none matched
     // otherwise there were only exclusions and none matched, so return true
-    if (hasIncludes) {      
+    if (hasIncludes) {
       return false;
     } else {
       return true;
     }
   }
-  
+
   /**
    * Dump metrics to a PrintWriter
    */
   void dump(PrintWriter pw) {
-    
+
     Set<MBeanServer> servers = new HashSet<MBeanServer>();
-    
+
     //
     // Retrieve all MBeanServer instances
     //
-    
+
     servers.add(ManagementFactory.getPlatformMBeanServer());
     servers.addAll(MBeanServerFactory.findMBeanServer(null));
-    
+
     for (MBeanServer server: servers) {
       //
       // Extract all MBeans
       //
-      
+
       Collection<ObjectName> names;
-      
+
       try {
         names = server.queryNames(new ObjectName("*:*"), null);
       } catch (MalformedObjectNameException mone) {
         return;
       }
-      
+
       //
       // Loop over the retrieved MBeans
       //
-      
+
       for (ObjectName name: names) {
         MBeanInfo info = null;
         ObjectInstance instance = null;
-        
+
         try {
           info = server.getMBeanInfo(name);
           instance = server.getObjectInstance(name);
-        } catch (IntrospectionException ie) {        
-        } catch (ReflectionException re) {        
-        } catch (InstanceNotFoundException infe) {        
+        } catch (IntrospectionException ie) {
+        } catch (ReflectionException re) {
+        } catch (InstanceNotFoundException infe) {
         } finally {
           if (null == info || null == instance) {
             continue;
           }
         }
-        
+
         String className = info.getClassName();
 
         if (!checkPatterns(className, includedMBeans, excludedMBeans)) {
           continue;
         }
-        
+
         //
         // Fill labels for the attribute
         //
-        
+
         Map<String,String> labels = new HashMap<String, String>();
-        
+
         //
         // Since there may be multiple instances of the same MBean class, we need to find an id for this
         // particular instance. As the call to queryNames returns a set, we can assume that the hashcodes
@@ -260,11 +260,11 @@ public class SensisionJMXPoller {
 
         labels.put("jmx.domain", name.getDomain());
         labels.put("jmx.hashcode", Integer.toHexString(name.hashCode()));
-        
+
         //
         // Extract the property lists of the MBean and store them as labels
         //
-        
+
         Hashtable<String,String> props = name.getKeyPropertyList();
 
         for (String propname: props.keySet()) {
@@ -272,26 +272,26 @@ public class SensisionJMXPoller {
         }
 
         MBeanAttributeInfo[] attrinfo = info.getAttributes();
-              
+
         //
         // Loop over the MBean attributes
         //
-        
-        for (MBeanAttributeInfo attr: attrinfo) {       
-          
+
+        for (MBeanAttributeInfo attr: attrinfo) {
+
           try {
             Object value = server.getAttribute(name, attr.getName());
-        
+
             //
             // Build the metric name as PREFIX + <className> + ":" + <attributeName>
-            
+
             StringBuilder sb = new StringBuilder(SENSISION_JMX_METRICS_PREFIX);
             sb.append(className);
             sb.append(":");
             sb.append(attr.getName());
-        
+
             String metricName = sb.toString();
-            
+
             if ("long".equals(attr.getType()) || "int".equals(attr.getType())) {
               dumpMetric(pw, metricName, labels, ((Number) value).longValue());
             } else if ("double".equals(attr.getType()) || "float".equals(attr.getType())) {
@@ -302,7 +302,7 @@ public class SensisionJMXPoller {
               dumpMetric(pw, metricName, labels, ((Boolean) value).booleanValue());
             } else if ("[Ljava.lang.String;".equals(attr.getType())) {
               sb.append(":stringlist");
-              
+
               sb.setLength(0);
               for (String s: (String[]) value) {
                 if (sb.length() > 0) {
@@ -321,26 +321,31 @@ public class SensisionJMXPoller {
             }
           } catch (Exception e) {}
         }
-      }      
+      }
     }
   }
-  
+
   /**
    * Write a single metric to an output PrintWriter
-   * 
+   *
    * @param pw
    * @param name
    * @param labels
    * @param value
    */
   private final void dumpMetric(PrintWriter pw, String name, Map<String,String> labels, Object value) {
-    
+
     if (!checkPatterns(name, includedMetrics, excludedMetrics)) {
       return;
     }
-    
+
+    if (OpenMetrics.useOpenMetrics()) {
+      OpenMetrics.dump(pw, name, labels, null, value);
+      return;
+    }
+
     StringBuilder sb = new StringBuilder();
-    
+
     try {
       sb.append(System.currentTimeMillis() * Sensision.TIME_UNITS_PER_MS);
       sb.append("/");
@@ -361,7 +366,7 @@ public class SensisionJMXPoller {
         first = false;
       }
       sb.append("} ");
-      
+
       if (value instanceof Long) {
         sb.append(Long.toString((Long) value));
       } else if (value instanceof Double) {
@@ -377,33 +382,33 @@ public class SensisionJMXPoller {
       pw.print(sb.toString());
     } catch (UnsupportedEncodingException uee) {
       // Can't happen, we're using UTF-8
-    }    
+    }
   }
-  
+
   private final void dumpTabularData(PrintWriter pw, String name, Map<String,String> labels, TabularData td) {
     for (Object rowkey: td.keySet()) {
-      
+
       if (rowkey instanceof List) {
         Map<String,String> rowlabels = new HashMap<String, String>();
         rowlabels.putAll(labels);
-        
+
         final CompositeData cd = td.get(((List) rowkey).toArray());
-        
+
         rowlabels.put("row", rowkey.toString());
-        
+
         //
         // If the composite data has two entries, 'key' and 'value', use the value of 'key' as the key and the value of 'value' as the value
         //
-        
+
         if (cd.containsKey("key") && cd.containsKey("value") && cd.values().size() == 2) {
           Map<String,Object> values = new HashMap<String, Object>();
-          
+
           Object k = cd.get("key");
           //if (k instanceof byte[]) {
           //  k = hex((byte[]) k);
           //}
           values.put(k.toString(), cd.get("value"));
-          try {                        
+          try {
             CompositeType ct = new CompositeType(
                 cd.getCompositeType().getTypeName(),
                 cd.getCompositeType().getDescription(),
@@ -412,31 +417,31 @@ public class SensisionJMXPoller {
                 new OpenType[] { cd.getCompositeType().getType("value")});
             CompositeDataSupport cds = new CompositeDataSupport(ct, values);
             dumpCompositeData(pw, name, rowlabels, cds);
-          } catch (OpenDataException ode) {            
+          } catch (OpenDataException ode) {
           }
         } else {
-          dumpCompositeData(pw, name, rowlabels, cd);                  
-        }        
+          dumpCompositeData(pw, name, rowlabels, cd);
+        }
       } else {
         // Weird, this should be impossible!
-      }      
-    } 
+      }
+    }
   }
 
   private final void dumpCompositeData(PrintWriter pw, String name, Map<String,String> labels, CompositeData cd) {
-    
+
     StringBuilder sb = new StringBuilder(name);
-    
+
     int len = sb.length();
-    
+
     for(String key: cd.getCompositeType().keySet()) {
       sb.setLength(len);
-      
+
       sb.append(":");
       sb.append(key);
 
       Object val = cd.get(key);
-      
+
       if (val instanceof Long || val instanceof Integer || val instanceof Short || val instanceof Byte) {
         dumpMetric(pw, sb.toString(), labels, ((Number) val).longValue());
       } else if (val instanceof Double || val instanceof Float) {
@@ -452,12 +457,12 @@ public class SensisionJMXPoller {
       } else {
         dumpMetric(pw, sb.toString(), labels, val.toString());
       }
-    }    
+    }
   }
 
-  private static final String HEXDIGITS = "0123456789abcdef";  
+  private static final String HEXDIGITS = "0123456789abcdef";
   private final String hex(byte[] bytes) {
-    
+
     StringBuilder sb = new StringBuilder();
     for (byte b: bytes) {
       sb.append(HEXDIGITS.charAt(b >>> 4));
@@ -465,7 +470,7 @@ public class SensisionJMXPoller {
     }
     return sb.toString();
   }
-  public static void premain(String agentArgs, Instrumentation instrumentation) {    
-    SensisionJMXPoller agent = new SensisionJMXPoller(agentArgs, instrumentation);    
+  public static void premain(String agentArgs, Instrumentation instrumentation) {
+    SensisionJMXPoller agent = new SensisionJMXPoller(agentArgs, instrumentation);
   }
 }

--- a/sensision/src/main/java/io/warp10/sensision/SensisionMetricsDumper.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionMetricsDumper.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -25,37 +25,37 @@ import java.io.PrintWriter;
  * SENSISION_HOME
  */
 public class SensisionMetricsDumper extends Thread {
-  
+
   /**
    * Delay in ms between two dumps
    */
   private long period;
-      
+
   private boolean useValueTS;
-  
+
   public SensisionMetricsDumper() {
-    
+
     if (Sensision.disable) {
       return;
     }
-    
+
     try {
       this.period = Long.valueOf(System.getProperty(Sensision.SENSISION_DUMP_PERIOD));
     } catch (NumberFormatException nfe) {
-      this.period = Sensision.DEFAULT_DUMP_PERIOD;        
+      this.period = Sensision.DEFAULT_DUMP_PERIOD;
     }
-  
+
     if ("true".equals(System.getProperty(Sensision.SENSISION_DUMP_CURRENTTS))) {
       this.useValueTS = false;
     } else {
       this.useValueTS = true;
     }
-    
+
     this.setDaemon(true);
     this.setName("Sensision MetricsDumper");
     this.start();
   }
-  
+
   @Override
   public void run() {
     while(true) {
@@ -69,30 +69,30 @@ public class SensisionMetricsDumper extends Thread {
       Sensision.flushEvents();
     }
   }
-  
+
   public static void flushMetrics(SensisionMetricsDumper dumper) {
     String home = System.getProperty(Sensision.SENSISION_HOME, Sensision.DEFAULT_SENSISION_HOME);
-    
+
     // Build the filename for the registration as a list of dot separated tokens
-    
+
     // First token is the current time reversed.
     String filename = Long.toHexString(Long.MAX_VALUE - System.currentTimeMillis());
-    
+
     // next token is the reversed timestamp of start time
     filename = filename + ".";
     filename = filename + Long.toHexString(Long.MAX_VALUE - Sensision.getStartTime());
-    
+
     // Next token is the Sensision uuid
     filename = filename + ".";
     filename = filename + Sensision.getUUID();
-    
+
     filename = filename + Sensision.SENSISION_METRICS_SUFFIX;
-    
+
     File metricsDir = new File(home, Sensision.SENSISION_METRICS_SUBDIR);
     File reg = new File(metricsDir, filename + ".tmp");
 
     PrintWriter out = null;
-    
+
     try {
       out = new PrintWriter(reg);
       if (null == dumper) {
@@ -106,7 +106,7 @@ public class SensisionMetricsDumper extends Thread {
         out.close();
       }
     }
-    
+
     if (0 == reg.length()) {
       // Delete if no metrics were written
       reg.delete();
@@ -114,10 +114,10 @@ public class SensisionMetricsDumper extends Thread {
       // Rename file atomically
 
       reg.renameTo(new File(metricsDir, filename));
-    }    
+    }
   }
-  
+
   public void dump(PrintWriter out) throws IOException {
-    Sensision.dump(out, this.useValueTS);
+    Sensision.dump(out, this.useValueTS, false);
   }
 }

--- a/sensision/src/main/java/io/warp10/sensision/SensisionMetricsServer.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionMetricsServer.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2022  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -61,7 +61,6 @@ public class SensisionMetricsServer extends Thread {
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
       if ("/metrics".equals(target)) {
-
         String valuets = request.getParameter("valuets");
 
         response.setContentType("text/plain;charset=utf-8");
@@ -75,7 +74,22 @@ public class SensisionMetricsServer extends Thread {
 
         PrintWriter out = response.getWriter();
 
-        server.dumpMetrics(out, null != valuets, OpenMetrics.useOpenMetrics());
+        server.dumpMetrics(out, null != valuets, false);
+      } else if ("/openmetrics".equals(target)) {
+        String valuets = request.getParameter("valuets");
+
+        response.setContentType("text/plain;charset=utf-8");
+        if (null != System.getProperty(Sensision.SENSISION_HTTP_NOKEEPALIVE)) {
+          response.setHeader("Connection", "close");
+        }
+        response.setHeader(Sensision.HTTP_HEADER_UUID, Sensision.getUUID());
+        response.setHeader(Sensision.HTTP_HEADER_TIMESTAMP, Long.toHexString(Long.MAX_VALUE - Sensision.getStartTime()));
+        response.setStatus(HttpServletResponse.SC_OK);
+        baseRequest.setHandled(true);
+
+        PrintWriter out = response.getWriter();
+
+        server.dumpMetrics(out, null != valuets, true);
       } else if ("/events".equals(target)) {
 
         boolean onDisk = Sensision.onDisk();

--- a/sensision/src/main/java/io/warp10/sensision/SensisionMetricsServer.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionMetricsServer.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2021  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -259,6 +259,10 @@ public class SensisionMetricsServer extends Thread {
     } catch (IOException ioe) {
       throw new RuntimeException(ioe);
     }
+  }
+
+  public void dumpMetrics(PrintWriter out, boolean useValueTimestamp) throws IOException {
+    Sensision.dump(out, useValueTimestamp, false);
   }
 
   public void dumpMetrics(PrintWriter out, boolean useValueTimestamp, boolean openmetrics) throws IOException {

--- a/sensision/src/main/java/io/warp10/sensision/SensisionMetricsServer.java
+++ b/sensision/src/main/java/io/warp10/sensision/SensisionMetricsServer.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -36,34 +36,34 @@ import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 public class SensisionMetricsServer extends Thread {
-  
+
   /**
    * Port on which the MetricsServer actually listens.
    */
   private int port;
-  
+
   public static final String SENSISION_SERVER_CONNECTOR = "sensision.server.connector";
 
   public static final String SENSISION_SERVER_BINDALL = "sensision.server.bindall";
-  
+
   public static final String SENSISION_SERVER_LASTEVENT_PARAM = "lastevent";
   public static final String SENSISION_SERVER_EVENTS_PARAM = "events";
   public static final String SENSISION_SERVER_PEEK_PARAM = "peek";
-  
+
   private static final class MetricsHandler extends AbstractHandler {
-   
+
     private final SensisionMetricsServer server;
-    
+
     public MetricsHandler(SensisionMetricsServer server) {
       this.server = server;
     }
-    
+
     @Override
-    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {        
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
       if ("/metrics".equals(target)) {
-        
+
         String valuets = request.getParameter("valuets");
-        
+
         response.setContentType("text/plain;charset=utf-8");
         if (null != System.getProperty(Sensision.SENSISION_HTTP_NOKEEPALIVE)) {
           response.setHeader("Connection", "close");
@@ -72,20 +72,20 @@ public class SensisionMetricsServer extends Thread {
         response.setHeader(Sensision.HTTP_HEADER_TIMESTAMP, Long.toHexString(Long.MAX_VALUE - Sensision.getStartTime()));
         response.setStatus(HttpServletResponse.SC_OK);
         baseRequest.setHandled(true);
-        
+
         PrintWriter out = response.getWriter();
-        
-        server.dumpMetrics(out, null != valuets);
+
+        server.dumpMetrics(out, null != valuets, OpenMetrics.useOpenMetrics());
       } else if ("/events".equals(target)) {
-        
+
         boolean onDisk = Sensision.onDisk();
-        
+
         boolean peek = null != request.getParameter(SENSISION_SERVER_PEEK_PARAM);
-        
+
         if (!onDisk || (onDisk && peek)) {
           long lastevent = -1L;
           int nevents = Integer.MAX_VALUE;
-          
+
           if (null != request.getParameter(SENSISION_SERVER_LASTEVENT_PARAM)) {
             lastevent = Long.parseLong(request.getParameter(SENSISION_SERVER_LASTEVENT_PARAM));
           }
@@ -102,8 +102,8 @@ public class SensisionMetricsServer extends Thread {
           response.setHeader(Sensision.HTTP_HEADER_TIMESTAMP, Long.toHexString(Long.MAX_VALUE - Sensision.getStartTime()));
           response.setStatus(HttpServletResponse.SC_OK);
           baseRequest.setHandled(true);
-          
-          server.dumpEvents(response, lastevent, nevents);          
+
+          server.dumpEvents(response, lastevent, nevents);
         } else {
           //
           // We're not having a peek, flush the events File
@@ -111,50 +111,50 @@ public class SensisionMetricsServer extends Thread {
           baseRequest.setHandled(true);
           Sensision.flushEvents();
         }
-        
+
       } else {
         baseRequest.setHandled(false);
         return;
       }
-    }        
+    }
   }
-  
+
   public SensisionMetricsServer() {
-    
+
     if (Sensision.disable) {
       return;
     }
-    
+
     try {
       this.port = Integer.valueOf(System.getProperty(Sensision.SENSISION_SERVER_PORT, "0"));
     } catch (NumberFormatException nfe) {
       throw new RuntimeException("Unable to parse server port " + System.getProperty(Sensision.SENSISION_SERVER_PORT));
     }
-    
+
     this.setDaemon(true);
     this.setName("[Sensision MetricsServer]");
     this.start();
   }
-  
+
   @Override
   public void run() {
-    
+
     Server server = new Server();
 
     QueuedThreadPool pool = new QueuedThreadPool();
-    pool.setDaemon(true);    
+    pool.setDaemon(true);
 
     server.setThreadPool(pool);
     server.setStopAtShutdown(true);
-    
+
     String conn = System.getProperty(SENSISION_SERVER_CONNECTOR, "nio");
-    
+
     boolean bindall = "true".equals(System.getProperty(SENSISION_SERVER_BINDALL));
-    
+
     if ("bio".equals(conn)) {
       SocketConnector connector = new SocketConnector();
       if (bindall) {
-        connector.setHost(null);        
+        connector.setHost(null);
       } else {
         connector.setHost("127.0.0.1");
       }
@@ -164,29 +164,29 @@ public class SensisionMetricsServer extends Thread {
     } else {
       SelectChannelConnector connector = new SelectChannelConnector();
       if (bindall) {
-        connector.setHost(null);        
+        connector.setHost(null);
       } else {
         connector.setHost("127.0.0.1");
-      }      
+      }
       connector.setPort(this.port);
       connector.setAcceptors(1);
       server.setConnectors(new Connector[] { connector });
     }
-    
+
     server.setHandler(new MetricsHandler(this));
     try {
       server.start();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-    
+
     //
     // Extract port so we can register this server
     //
-    
-    //this.port = ((ServerSocketChannel) server.getConnectors()[0].getTransport()).socket().getLocalPort();      
+
+    //this.port = ((ServerSocketChannel) server.getConnectors()[0].getTransport()).socket().getLocalPort();
     this.port = server.getConnectors()[0].getLocalPort();
-    
+
     this.setName("[Sensision MetricsServer (" + this.port + ")]");
 
     //
@@ -194,36 +194,36 @@ public class SensisionMetricsServer extends Thread {
     // This way we get a chance to recreate the target file if it was deleted.
     // Re-register every minute.
     //
-    
+
     while (!server.isStopping()) {
       try {
         register();
-      } catch (Throwable t) {        
+      } catch (Throwable t) {
       }
       try {
         Thread.sleep(60 * 1000L);
-      } catch (InterruptedException ie) {        
+      } catch (InterruptedException ie) {
       }
     }
-    
+
     try {
       server.join();
     } catch (InterruptedException ie) {
       throw new RuntimeException(ie);
     }
   }
-  
+
   /**
    * Register the server under SENSISION_HOME
    */
   private void register() {
     File targetDir = Sensision.getTargetsDir();
-    
+
     // Build the filename for the registration as a list of dot separated tokens
     // First token is the reversed timestamp of registration time
     String filename = Long.toHexString(Long.MAX_VALUE - Sensision.getStartTime());
     // Second token is the Sensision polling hint
-    filename = filename + "." + System.getProperty(Sensision.SENSISION_POLLING_HINT, Sensision.DEFAULT_SENSISION_POLLING_HINT);   
+    filename = filename + "." + System.getProperty(Sensision.SENSISION_POLLING_HINT, Sensision.DEFAULT_SENSISION_POLLING_HINT);
     // Third token is the Sensision uuid
     filename = filename + ".";
     filename = filename + Sensision.getUUID();
@@ -236,35 +236,35 @@ public class SensisionMetricsServer extends Thread {
     }
     // Next is a suffix
     filename = filename + Sensision.SENSISION_TARGETS_SUFFIX;
-    
+
     File reg = new File(targetDir, filename);
-    
+
     // Force file to be deleted on exit, this way we'll only
     // have stale files for apps which terminated abnormally
     reg.deleteOnExit();
-    
+
     //
     // Do nothing if file already exists
     //
-    
+
     if (reg.exists()) {
       return;
     }
-    
+
     try {
       // Create file
       Writer writer = new  FileWriter(reg);
       writer.append("");
-      writer.close();                
+      writer.close();
     } catch (IOException ioe) {
       throw new RuntimeException(ioe);
     }
   }
-  
-  public void dumpMetrics(PrintWriter out, boolean useValueTimestamp) throws IOException {
-    Sensision.dump(out, useValueTimestamp);          
+
+  public void dumpMetrics(PrintWriter out, boolean useValueTimestamp, boolean openmetrics) throws IOException {
+    Sensision.dump(out, useValueTimestamp, openmetrics);
   }
-  
+
   /**
    * We do not synchronize this method with the 'event' one in Sensision so as to not
    * slow down event storage when dumping events.
@@ -273,15 +273,15 @@ public class SensisionMetricsServer extends Thread {
     //
     // Determine start offset to display
     //
-        
+
     List<String> events = Sensision.getEvents();
-        
+
     long curevent = Sensision.getCurrentEvent();
-    
+
     if (0 == events.size() || -1 == curevent || n <= 0) {
       return;
     }
-    
+
     // Shift lastevent to be closer to the current event if
     // it has already been overwritten
     if (lastevent >= 0L) {
@@ -289,23 +289,23 @@ public class SensisionMetricsServer extends Thread {
     } else {
       lastevent = Math.max(curevent - events.size(), -1L);
     }
-    
+
     // Adjust n
     if (n > events.size()) {
       n = events.size();
     }
-    
+
     response.setHeader(Sensision.HTTP_HEADER_LASTEVENT, Long.toString(Math.min(curevent, lastevent + events.size())));
 
     PrintWriter out = response.getWriter();
-    
+
     while(n > 0 && lastevent < Sensision.getCurrentEvent()) {
       // Increment the event number we will display next
       lastevent++;
-      
+
       // Adjust lastevent to take into consideration the possible arrival of new events
       lastevent = Math.max(Sensision.getCurrentEvent() - events.size() + 1, lastevent);
-      
+
       // Account for cycle
       int idx = (int) (lastevent % events.size());
       out.println(events.get(idx));


### PR DESCRIPTION
Allows to output OpenMetrics format when sensision.openmetrics is defined as a JVM property.

This does not apply to events, only to metrics exposed via /metrics

Due to the limitation in the types supported by OpenMetrics STRING and BOOLEAN values are not exposed.

Classes, label names and values may be altered to stick to OpenMetrics naming conventions.